### PR TITLE
[codex] Align short-option cluster and help/version parsing coverage

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -402,7 +402,7 @@ fn help_or_version_arg(argv: &[OsString]) -> Option<OsString> {
                     return Some(OsString::from(format!("-{flag}")));
                 }
 
-                if matches!(flag, 't' | 'd' | 'p') {
+                if short_cluster_stops_value_parsing(flag) {
                     break;
                 }
             }
@@ -414,7 +414,7 @@ fn help_or_version_arg(argv: &[OsString]) -> Option<OsString> {
 
 fn parse_short_verbose_cluster(arg: &str, verbosity: &mut u8) -> Result<(), clap::Error> {
     for flag in arg[1..].chars() {
-        if matches!(flag, 't' | 'd' | 'p') {
+        if short_cluster_stops_value_parsing(flag) {
             break;
         }
 
@@ -424,6 +424,10 @@ fn parse_short_verbose_cluster(arg: &str, verbosity: &mut u8) -> Result<(), clap
     }
 
     Ok(())
+}
+
+fn short_cluster_stops_value_parsing(flag: char) -> bool {
+    matches!(flag, 't' | 'd')
 }
 
 fn increment_verbose_level(verbosity: &mut u8) -> Result<(), clap::Error> {
@@ -650,6 +654,23 @@ mod tests {
         assert_eq!(args_long_zero.verbose, 0);
         assert!(Args::try_parse_from(["rustow", "--verbose=invalid", "mypackage"]).is_err());
         assert!(Args::try_parse_from(["rustow", "--verbose=6", "mypackage"]).is_err());
+    }
+
+    #[test]
+    fn test_verbose_option_cluster_with_compat_before() {
+        let args = Args::parse_from(["rustow", "-pv", "mypackage"]);
+
+        assert!(args.compat);
+        assert_eq!(args.verbose, 1);
+        assert_eq!(args.packages, vec!["mypackage"]);
+    }
+
+    #[test]
+    fn test_verbose_option_cluster_with_compat_after() {
+        let args = Args::parse_from(["rustow", "-vp", "mypackage"]);
+
+        assert!(args.compat);
+        assert_eq!(args.verbose, 1);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -767,6 +767,18 @@ mod tests {
     }
 
     #[test]
+    fn test_help_takes_precedence_after_packages() {
+        let error = Args::try_parse_from(["rustow", "mypackage", "--help"]).unwrap_err();
+        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayHelp);
+
+        let error = Args::try_parse_from(["rustow", "mypackage", "-h"]).unwrap_err();
+        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayHelp);
+
+        let error = Args::try_parse_from(["rustow", "mypackage", "-V"]).unwrap_err();
+        assert_eq!(error.kind(), clap::error::ErrorKind::DisplayVersion);
+    }
+
+    #[test]
     fn test_try_parse_from_with_operation_groups_returns_parse_errors() {
         let error =
             Args::try_parse_from_with_operation_groups(["rustow", "--verbose=6", "mypackage"])
@@ -1000,6 +1012,28 @@ mod tests {
                 packages: vec!["old".to_string()],
             }]
         );
+    }
+
+    #[test]
+    fn test_short_cluster_with_value_flag_stops_verbosity_counting() {
+        let args = Args::parse_from(["rustow", "-tv", "mypackage"]);
+        assert_eq!(args.target, Some(PathBuf::from("v")));
+        assert_eq!(args.verbose, 0);
+        assert_eq!(args.packages, vec!["mypackage"]);
+    }
+
+    #[test]
+    fn test_short_cluster_mode_value_attached_to_target() {
+        let parsed_args = Args::parse_from_with_operation_groups(["rustow", "-Dt/tmp/stow", "pkg"]);
+
+        assert_eq!(
+            parsed_args.operation_groups,
+            vec![OperationGroup {
+                mode: OperationMode::Delete,
+                packages: vec!["pkg".to_string()],
+            }]
+        );
+        assert_eq!(parsed_args.args.target, Some(PathBuf::from("/tmp/stow")));
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -299,12 +299,13 @@ fn validate_separate_option_values(argv: &[OsString]) -> Result<(), clap::Error>
             continue;
         }
 
-        if arg.starts_with('-') && !arg.starts_with("--") && arg.len() > 1 {
-            if short_option_cluster_consumes_value(&arg, &mut current_mode) {
-                if short_option_cluster_needs_next_value(&arg) {
-                    option_waiting_for_value = Some(arg.into_owned());
-                }
-            }
+        if arg.starts_with('-')
+            && !arg.starts_with("--")
+            && arg.len() > 1
+            && short_option_cluster_consumes_value(&arg, &mut current_mode)
+            && short_option_cluster_needs_next_value(&arg)
+        {
+            option_waiting_for_value = Some(arg.into_owned());
         }
     }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -741,6 +741,12 @@ mod tests {
 
         let error = Args::try_parse_from(["rustow", "-Rt", "--simulate", "mypackage"]).unwrap_err();
         assert!(error.to_string().contains("requires a value"));
+
+        let error = Args::try_parse_from(["rustow", "--defer", "--help", "mypackage"]).unwrap_err();
+        assert!(error.to_string().contains("requires a value"));
+
+        let error = Args::try_parse_from(["rustow", "--override", "-V", "mypackage"]).unwrap_err();
+        assert!(error.to_string().contains("requires a value"));
     }
 
     #[test]
@@ -756,6 +762,24 @@ mod tests {
         assert_eq!(args.dir, Some(PathBuf::from("-D")));
         assert_eq!(args.ignore_patterns, vec!["-S"]);
         assert_eq!(args.defer_conflicts, vec!["--simulate"]);
+        assert_eq!(args.packages, vec!["mypackage"]);
+    }
+
+    #[test]
+    fn test_hyphen_prefixed_option_values_for_all_pattern_lists() {
+        let args = Args::parse_from([
+            "rustow",
+            "--ignore=--help",
+            "--override=--verbose=0",
+            "--defer=--version",
+            "--target=--verbose",
+            "mypackage",
+        ]);
+
+        assert_eq!(args.ignore_patterns, vec!["--help"]);
+        assert_eq!(args.override_conflicts, vec!["--verbose=0"]);
+        assert_eq!(args.defer_conflicts, vec!["--version"]);
+        assert_eq!(args.target, Some(PathBuf::from("--verbose")));
         assert_eq!(args.packages, vec!["mypackage"]);
     }
 
@@ -1034,6 +1058,20 @@ mod tests {
             }]
         );
         assert_eq!(parsed_args.args.target, Some(PathBuf::from("/tmp/stow")));
+    }
+
+    #[test]
+    fn test_short_cluster_mode_before_dir_value() {
+        let parsed_args = Args::parse_from_with_operation_groups(["rustow", "-Sd/tmp/stow", "pkg"]);
+
+        assert_eq!(
+            parsed_args.operation_groups,
+            vec![OperationGroup {
+                mode: OperationMode::Stow,
+                packages: vec!["pkg".to_string()],
+            }]
+        );
+        assert_eq!(parsed_args.args.dir, Some(PathBuf::from("/tmp/stow")));
     }
 
     #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -516,6 +516,77 @@ fn test_default_tree_folding_creates_directory_symlink() {
 }
 
 #[test]
+fn test_no_folding_keeps_directory_open() {
+    let (_temp_dir, stow_dir, target_dir): (TempDir, PathBuf, PathBuf) = setup_test_environment();
+    let package_name = "no_fold_pkg";
+    let package_dir = stow_dir.join(package_name);
+    fs::create_dir_all(package_dir.join("bin")).unwrap();
+    fs::write(package_dir.join("bin/tool"), "#!/bin/sh\n").unwrap();
+
+    let folded_target_dir = target_dir.join("folded");
+    let open_target_dir = target_dir.join("open");
+    fs::create_dir_all(&folded_target_dir).unwrap();
+    fs::create_dir_all(&open_target_dir).unwrap();
+
+    let folded_config = create_test_config(
+        stow_dir.clone(),
+        folded_target_dir.clone(),
+        vec![package_name.to_string()],
+        false,
+        0,
+    );
+    let folded_reports = stow_packages(&folded_config).unwrap();
+    assert!(
+        folded_reports
+            .iter()
+            .any(|report| report.original_action.target_path == folded_target_dir.join("bin")),
+        "Expected an action for folded target path"
+    );
+    assert!(
+        fs::symlink_metadata(folded_target_dir.join("bin"))
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "bin should be folded to symlink with default options"
+    );
+
+    let mut open_config = create_test_config(
+        stow_dir.clone(),
+        open_target_dir.clone(),
+        vec![package_name.to_string()],
+        false,
+        0,
+    );
+    open_config.no_folding = true;
+    let open_reports = stow_packages(&open_config).unwrap();
+    assert!(
+        open_reports
+            .iter()
+            .any(|report| report.original_action.target_path == open_target_dir.join("bin")),
+        "Expected an action for open target path"
+    );
+    assert!(
+        open_target_dir.join("bin").is_dir(),
+        "bin should remain a directory"
+    );
+    assert!(
+        !fs::symlink_metadata(open_target_dir.join("bin"))
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "bin should not be a symlink when --no-folding is enabled"
+    );
+
+    assert!(
+        fs::symlink_metadata(open_target_dir.join("bin/tool"))
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "Nested target should still be symlinked"
+    );
+}
+
+#[test]
 fn test_split_open_folded_tree_for_second_package() {
     let (_temp_dir, stow_dir, target_dir) = setup_test_environment();
     let package1_dir = stow_dir.join("perl");
@@ -578,6 +649,153 @@ fn test_split_open_folded_tree_for_second_package() {
             .file_type()
             .is_symlink(),
         "new package entry should be linked"
+    );
+}
+
+#[test]
+fn test_no_folding_split_open_with_existing_folded_tree() {
+    let (_temp_dir, stow_dir, target_dir) = setup_test_environment();
+    let package1_dir = stow_dir.join("perl");
+    let package2_dir = stow_dir.join("emacs");
+    fs::create_dir_all(package1_dir.join("bin")).unwrap();
+    fs::create_dir_all(package2_dir.join("bin")).unwrap();
+    fs::write(package1_dir.join("bin/perl"), "perl").unwrap();
+    fs::write(package2_dir.join("bin/emacs"), "emacs").unwrap();
+
+    let package1_config = create_test_config(
+        stow_dir.clone(),
+        target_dir.clone(),
+        vec!["perl".to_string()],
+        false,
+        0,
+    );
+    stow_packages(&package1_config).unwrap();
+    assert!(
+        fs::symlink_metadata(target_dir.join("bin"))
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "first package should fold bin"
+    );
+
+    let mut package2_config = create_test_config(
+        stow_dir.clone(),
+        target_dir.clone(),
+        vec!["emacs".to_string()],
+        false,
+        0,
+    );
+    package2_config.no_folding = true;
+    let reports = stow_packages(&package2_config).unwrap();
+
+    assert!(
+        reports.iter().any(|report| {
+            report.original_action.target_path == target_dir.join("bin")
+                && report.original_action.action_type == ActionType::DeleteSymlink
+        }),
+        "split-open should delete the old folded bin symlink"
+    );
+    assert!(
+        target_dir.join("bin").is_dir()
+            && !fs::symlink_metadata(target_dir.join("bin"))
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+        "bin should become a real directory after split-open"
+    );
+    assert!(
+        fs::symlink_metadata(target_dir.join("bin/perl"))
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "old package entry should be relinked"
+    );
+    assert!(
+        fs::symlink_metadata(target_dir.join("bin/emacs"))
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "new package entry should be linked"
+    );
+}
+
+#[test]
+fn test_no_folding_split_open_preserves_package_alias_target() {
+    let (_temp_dir, stow_dir, target_dir): (TempDir, PathBuf, PathBuf) = setup_test_environment();
+    let real_package_dir = stow_dir.join("realpkg");
+    let alias_package_dir = stow_dir.join("aliaspkg");
+    let second_package_dir = stow_dir.join("second");
+
+    fs::create_dir_all(real_package_dir.join("bin")).unwrap();
+    fs::create_dir_all(second_package_dir.join("bin")).unwrap();
+    fs::write(real_package_dir.join("bin/tool"), "tool").unwrap();
+    fs::write(second_package_dir.join("bin/config"), "config").unwrap();
+
+    rustow::fs_utils::create_symlink(&alias_package_dir, Path::new("realpkg")).unwrap();
+
+    let alias_config = create_test_config(
+        stow_dir.clone(),
+        target_dir.clone(),
+        vec!["aliaspkg".to_string()],
+        false,
+        0,
+    );
+    stow_packages(&alias_config).unwrap();
+    assert!(
+        fs::symlink_metadata(target_dir.join("bin"))
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "alias package first stow should fold bin"
+    );
+
+    let mut split_config = create_test_config(
+        stow_dir.clone(),
+        target_dir.clone(),
+        vec!["second".to_string()],
+        false,
+        0,
+    );
+    split_config.no_folding = true;
+    let reports = stow_packages(&split_config).unwrap();
+
+    assert!(
+        reports.iter().any(|report| {
+            report.original_action.target_path == target_dir.join("bin")
+                && report.original_action.action_type == ActionType::DeleteSymlink
+        }),
+        "split-open should delete folded bin symlink"
+    );
+    assert!(
+        target_dir.join("bin").is_dir(),
+        "bin should become a real directory after split-open"
+    );
+    assert!(
+        !fs::symlink_metadata(target_dir.join("bin"))
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "bin should be directory with --no-folding"
+    );
+    assert!(
+        fs::symlink_metadata(target_dir.join("bin/tool"))
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "existing alias-managed file should keep symlink target"
+    );
+    assert!(
+        fs::read_link(target_dir.join("bin/tool"))
+            .unwrap()
+            .ends_with("aliaspkg/bin/tool"),
+        "alias symlink target should remain package alias"
+    );
+    assert!(
+        fs::symlink_metadata(target_dir.join("bin/config"))
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "new package file should be linked"
     );
 }
 
@@ -1741,8 +1959,8 @@ fn test_execute_actions_basic_creation() {
         "Target nested_file_sim.txt should not exist in simulate mode"
     );
 
-    // TODO: Add Scenario 4 (which is more specific about --no-folding if it differs)
-    // For now, Scenario 3 covers parent dir creation implicitly handled by CreateSymlink's logic.
+    // Scenario 4: --no-folding compatibility differences are covered by
+    // test_no_folding_keeps_directory_open.
 }
 
 // Add more tests as needed:
@@ -2936,6 +3154,116 @@ fn test_binary_mixed_same_package_delete_and_stow_prunes_stale_symlink() {
     assert!(fs::symlink_metadata(target_dir.join("bin/old")).is_err());
     assert!(target_dir.join("bin/tool").exists());
     assert!(target_dir.join("bin/new").exists());
+}
+
+#[test]
+fn test_binary_no_folding_keeps_directory_open() {
+    let (_temp_dir, stow_dir, target_dir): (TempDir, PathBuf, PathBuf) = setup_test_environment();
+    let package_dir = stow_dir.join("pkg");
+    fs::create_dir_all(package_dir.join("bin")).unwrap();
+    fs::write(package_dir.join("bin/tool"), "tool").unwrap();
+
+    let output = run_rustow([
+        "--no-folding",
+        "-d",
+        stow_dir.to_str().unwrap(),
+        "-t",
+        target_dir.to_str().unwrap(),
+        "pkg",
+    ]);
+
+    assert!(
+        output.status.success(),
+        "rustow failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        target_dir.join("bin").is_dir(),
+        "bin should remain a directory"
+    );
+    assert!(
+        !fs::symlink_metadata(target_dir.join("bin"))
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "bin should not be a symlink when --no-folding is enabled"
+    );
+    assert!(
+        fs::symlink_metadata(target_dir.join("bin/tool"))
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "bin/tool should be symlinked"
+    );
+}
+
+#[test]
+fn test_binary_no_folding_split_open_with_existing_folded_tree() {
+    let (_temp_dir, stow_dir, target_dir): (TempDir, PathBuf, PathBuf) = setup_test_environment();
+
+    let package1_dir = stow_dir.join("perl");
+    let package2_dir = stow_dir.join("emacs");
+    fs::create_dir_all(package1_dir.join("bin")).unwrap();
+    fs::create_dir_all(package2_dir.join("bin")).unwrap();
+    fs::write(package1_dir.join("bin/perl"), "perl").unwrap();
+    fs::write(package2_dir.join("bin/emacs"), "emacs").unwrap();
+
+    let first = run_rustow([
+        "-d",
+        stow_dir.to_str().unwrap(),
+        "-t",
+        target_dir.to_str().unwrap(),
+        "perl",
+    ]);
+    assert!(
+        first.status.success(),
+        "initial rustow failed: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    assert!(
+        fs::symlink_metadata(target_dir.join("bin"))
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "first package should fold bin"
+    );
+
+    let second = run_rustow([
+        "--no-folding",
+        "-d",
+        stow_dir.to_str().unwrap(),
+        "-t",
+        target_dir.to_str().unwrap(),
+        "emacs",
+    ]);
+    assert!(
+        second.status.success(),
+        "second rustow failed: {}",
+        String::from_utf8_lossy(&second.stderr)
+    );
+
+    assert!(
+        target_dir.join("bin").is_dir()
+            && !fs::symlink_metadata(target_dir.join("bin"))
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+        "bin should become a real directory after split-open"
+    );
+    assert!(
+        fs::symlink_metadata(target_dir.join("bin/perl"))
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "old package entry should be relinked"
+    );
+    assert!(
+        fs::symlink_metadata(target_dir.join("bin/emacs"))
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "new package entry should be linked"
+    );
 }
 
 #[test]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3652,6 +3652,25 @@ fn test_binary_verbose_parse_errors_and_help_exit_codes() {
 }
 
 #[test]
+fn test_binary_help_and_version_keep_precedence_after_packages() {
+    let help_output = run_rustow(["pkg", "--help"]);
+    assert_eq!(help_output.status.code(), Some(0));
+    assert!(String::from_utf8_lossy(&help_output.stdout).contains("Usage:"));
+
+    let version_output = run_rustow(["pkg", "-V"]);
+    assert_eq!(version_output.status.code(), Some(0));
+    assert!(!String::from_utf8_lossy(&version_output.stdout).is_empty());
+
+    let help_with_extra_arg_output = run_rustow(["pkg", "--help", "extra"]);
+    assert_eq!(help_with_extra_arg_output.status.code(), Some(0));
+    assert!(String::from_utf8_lossy(&help_with_extra_arg_output.stdout).contains("Usage:"));
+
+    let version_with_extra_arg_output = run_rustow(["pkg", "--version", "extra"]);
+    assert_eq!(version_with_extra_arg_output.status.code(), Some(0));
+    assert!(!String::from_utf8_lossy(&version_with_extra_arg_output.stdout).is_empty());
+}
+
+#[test]
 fn test_binary_rejects_operation_flags_as_missing_option_values() {
     for args in [
         vec!["-d", "-D", "pkg"],

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -3613,6 +3613,31 @@ fn test_binary_verbose_numeric_level_is_accepted() {
 }
 
 #[test]
+fn test_binary_compat_verbosity_cluster_preserves_verbosity() {
+    let (_temp_dir, stow_dir, target_dir): (TempDir, PathBuf, PathBuf) = setup_test_environment();
+    let package_dir = stow_dir.join("pkg");
+    fs::create_dir_all(package_dir.join("bin")).unwrap();
+    fs::write(package_dir.join("bin/tool"), "tool").unwrap();
+
+    let output = run_rustow([
+        "-d",
+        stow_dir.to_str().unwrap(),
+        "-t",
+        target_dir.to_str().unwrap(),
+        "-pv",
+        "pkg",
+    ]);
+
+    assert!(
+        output.status.success(),
+        "rustow failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stderr).contains("Summary:"));
+    assert!(target_dir.join("bin/tool").exists());
+}
+
+#[test]
 fn test_binary_verbose_parse_errors_and_help_exit_codes() {
     let invalid_verbose = run_rustow(["--verbose=6", "pkg"]);
     assert_eq!(invalid_verbose.status.code(), Some(2));


### PR DESCRIPTION
## Summary
- Extend CLI compatibility tests for GNU Stow-like parsing in the mixed-operation parser path.
- Harden help/version precedence behavior for option-value rejection paths.
- Add coverage for clustered short options with attached values after mode flags.

## Why
These cases close remaining parsing edge cases around operation mode switches and short-option clusters so Rustow's CLI handling matches GNU Stow's behavior in CI-covered scenarios.

## Validation
- `cargo test --all -- --nocapture`
- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
