### PR TITLE
Refactor internal module structure

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -47,97 +47,24 @@ impl Config {
         args: Args,
         path_displays: &mut Vec<PathDisplayOverride>,
     ) -> RustowResult<Self> {
-        // 1. Determine StowMode
-        let mode: StowMode = if args.delete {
-            StowMode::Delete
-        } else if args.restow {
-            StowMode::Restow
-        } else {
-            StowMode::Stow
-        };
+        let mode = stow_mode_from_args(&args);
 
-        // 2. Resolve stow_dir
-        let stow_dir_path_unresolved: PathBuf = match args.dir {
-            Some(path) => path,
-            None => match env::var("STOW_DIR") {
-                Ok(val) => PathBuf::from(val),
-                Err(_) => env::current_dir().map_err(|e| {
-                    RustowError::Config(ConfigError::InvalidStowDir(format!(
-                        "Failed to get current directory for stow_dir: {}",
-                        e
-                    )))
-                })?,
-            },
-        };
+        let stow_dir_path_unresolved = unresolved_stow_dir(&args)?;
         let stow_dir_display = crate::cli::path_display(&stow_dir_path_unresolved, path_displays);
-        let stow_dir: PathBuf =
-            fs_utils::canonicalize_path(&stow_dir_path_unresolved).map_err(|e| match e {
-                RustowError::Fs(FsError::Canonicalize { source, .. }) => {
-                    RustowError::Config(ConfigError::InvalidStowDir(format!(
-                        "Failed to canonicalize stow directory '{}': {}",
-                        stow_dir_display, source
-                    )))
-                },
-                RustowError::Fs(fs_error) => {
-                    RustowError::Config(ConfigError::InvalidStowDir(format!(
-                        "Failed to canonicalize stow directory '{}': {}",
-                        stow_dir_display, fs_error
-                    )))
-                },
-                _ => RustowError::Config(ConfigError::InvalidStowDir(format!(
-                    "An unexpected error occurred while canonicalizing stow directory '{}': {}",
-                    stow_dir_display, e
-                ))),
-            })?;
+        let stow_dir = canonicalize_stow_dir(&stow_dir_path_unresolved, &stow_dir_display)?;
         path_displays.push(PathDisplayOverride::new(
             stow_dir.clone(),
             stow_dir_display.clone(),
         ));
 
-        // 3. Resolve target_dir
-        let (target_dir_path_unresolved, target_dir_display): (PathBuf, String) = match args.target
-        {
-            Some(path) => {
-                let display = crate::cli::path_display(&path, path_displays);
-                (path, display)
-            },
-            None => {
-                let path = stow_dir.parent().ok_or_else(|| {
-                        RustowError::Config(ConfigError::InvalidTargetDir(format!(
-                            "Stow directory '{}' has no parent, cannot determine default target directory",
-                            stow_dir_display
-                        )))
-                    })?.to_path_buf();
-                let display = display_parent(&stow_dir_display).unwrap_or_else(|| {
-                    let unresolved_display = stow_dir_path_unresolved.display().to_string();
-                    if stow_dir_display == unresolved_display {
-                        crate::cli::path_display(&path, path_displays)
-                    } else {
-                        format!("{}{}..", stow_dir_display, std::path::MAIN_SEPARATOR)
-                    }
-                });
-                (path, display)
-            },
-        };
-        let target_dir: PathBuf = fs_utils::canonicalize_path(&target_dir_path_unresolved)
-            .map_err(|e| match e {
-                RustowError::Fs(FsError::Canonicalize { source, .. }) => {
-                    RustowError::Config(ConfigError::InvalidTargetDir(format!(
-                        "Failed to canonicalize target directory '{}': {}",
-                        target_dir_display, source
-                    )))
-                },
-                RustowError::Fs(fs_error) => {
-                    RustowError::Config(ConfigError::InvalidTargetDir(format!(
-                        "Failed to canonicalize target directory '{}': {}",
-                        target_dir_display, fs_error
-                    )))
-                },
-                _ => RustowError::Config(ConfigError::InvalidTargetDir(format!(
-                    "An unexpected error occurred while canonicalizing target directory '{}': {}",
-                    target_dir_display, e
-                ))),
-            })?;
+        let (target_dir_path_unresolved, target_dir_display) = unresolved_target_dir(
+            &args,
+            &stow_dir,
+            &stow_dir_path_unresolved,
+            &stow_dir_display,
+            path_displays,
+        )?;
+        let target_dir = canonicalize_target_dir(&target_dir_path_unresolved, &target_dir_display)?;
         path_displays.push(PathDisplayOverride::new(
             target_dir.clone(),
             target_dir_display,
@@ -149,43 +76,9 @@ impl Config {
             ))
         })?;
 
-        // Compile override and defer patterns
-        let mut overrides_compiled: Vec<Regex> = Vec::new();
-        for pattern_str in &args.override_conflicts {
-            match Regex::new(pattern_str) {
-                Ok(re) => overrides_compiled.push(re),
-                Err(e) => {
-                    return Err(RustowError::Config(ConfigError::InvalidRegexPattern(
-                        format!("Invalid --override pattern '{}': {}", pattern_str, e),
-                    )));
-                },
-            }
-        }
-
-        let mut defers_compiled: Vec<Regex> = Vec::new();
-        for pattern_str in &args.defer_conflicts {
-            match Regex::new(pattern_str) {
-                Ok(re) => defers_compiled.push(re),
-                Err(e) => {
-                    return Err(RustowError::Config(ConfigError::InvalidRegexPattern(
-                        format!("Invalid --defer pattern '{}': {}", pattern_str, e),
-                    )));
-                },
-            }
-        }
-
-        // Compile ignore patterns
-        let mut ignore_patterns_compiled: Vec<Regex> = Vec::new();
-        for pattern_str in &args.ignore_patterns {
-            match Regex::new(pattern_str) {
-                Ok(re) => ignore_patterns_compiled.push(re),
-                Err(e) => {
-                    return Err(RustowError::Config(ConfigError::InvalidRegexPattern(
-                        format!("Invalid --ignore pattern '{}': {}", pattern_str, e),
-                    )));
-                },
-            }
-        }
+        let overrides = compile_regex_patterns(&args.override_conflicts, "--override")?;
+        let defers = compile_regex_patterns(&args.defer_conflicts, "--defer")?;
+        let ignore_patterns = compile_regex_patterns(&args.ignore_patterns, "--ignore")?;
 
         Ok(Self {
             target_dir,
@@ -197,14 +90,141 @@ impl Config {
             adopt: args.adopt,
             no_folding: args.no_folding,
             dotfiles: args.dotfiles,
-            overrides: overrides_compiled,
-            defers: defers_compiled,
-            ignore_patterns: ignore_patterns_compiled,
+            overrides,
+            defers,
+            ignore_patterns,
             simulate: args.simulate,
             verbosity: args.verbose,
             home_dir,
         })
     }
+}
+
+fn stow_mode_from_args(args: &Args) -> StowMode {
+    if args.delete {
+        StowMode::Delete
+    } else if args.restow {
+        StowMode::Restow
+    } else {
+        StowMode::Stow
+    }
+}
+
+fn unresolved_stow_dir(args: &Args) -> RustowResult<PathBuf> {
+    match &args.dir {
+        Some(path) => Ok(path.clone()),
+        None => match env::var("STOW_DIR") {
+            Ok(val) => Ok(PathBuf::from(val)),
+            Err(_) => env::current_dir().map_err(|e| {
+                RustowError::Config(ConfigError::InvalidStowDir(format!(
+                    "Failed to get current directory for stow_dir: {}",
+                    e
+                )))
+            }),
+        },
+    }
+}
+
+fn canonicalize_stow_dir(path: &Path, display: &str) -> RustowResult<PathBuf> {
+    fs_utils::canonicalize_path(path).map_err(|e| match e {
+        RustowError::Fs(FsError::Canonicalize { source, .. }) => {
+            RustowError::Config(ConfigError::InvalidStowDir(format!(
+                "Failed to canonicalize stow directory '{}': {}",
+                display, source
+            )))
+        },
+        RustowError::Fs(fs_error) => RustowError::Config(ConfigError::InvalidStowDir(format!(
+            "Failed to canonicalize stow directory '{}': {}",
+            display, fs_error
+        ))),
+        _ => RustowError::Config(ConfigError::InvalidStowDir(format!(
+            "An unexpected error occurred while canonicalizing stow directory '{}': {}",
+            display, e
+        ))),
+    })
+}
+
+fn unresolved_target_dir(
+    args: &Args,
+    stow_dir: &Path,
+    stow_dir_path_unresolved: &Path,
+    stow_dir_display: &str,
+    path_displays: &[PathDisplayOverride],
+) -> RustowResult<(PathBuf, String)> {
+    match &args.target {
+        Some(path) => {
+            let display = crate::cli::path_display(path, path_displays);
+            Ok((path.clone(), display))
+        },
+        None => {
+            let path = stow_dir
+                .parent()
+                .ok_or_else(|| {
+                    RustowError::Config(ConfigError::InvalidTargetDir(format!(
+                        "Stow directory '{}' has no parent, cannot determine default target directory",
+                        stow_dir_display
+                    )))
+                })?
+                .to_path_buf();
+            let display = default_target_display(
+                &path,
+                stow_dir_path_unresolved,
+                stow_dir_display,
+                path_displays,
+            );
+
+            Ok((path, display))
+        },
+    }
+}
+
+fn default_target_display(
+    target_path: &Path,
+    stow_dir_path_unresolved: &Path,
+    stow_dir_display: &str,
+    path_displays: &[PathDisplayOverride],
+) -> String {
+    display_parent(stow_dir_display).unwrap_or_else(|| {
+        let unresolved_display = stow_dir_path_unresolved.display().to_string();
+        if stow_dir_display == unresolved_display {
+            crate::cli::path_display(target_path, path_displays)
+        } else {
+            format!("{}{}..", stow_dir_display, std::path::MAIN_SEPARATOR)
+        }
+    })
+}
+
+fn canonicalize_target_dir(path: &Path, display: &str) -> RustowResult<PathBuf> {
+    fs_utils::canonicalize_path(path).map_err(|e| match e {
+        RustowError::Fs(FsError::Canonicalize { source, .. }) => {
+            RustowError::Config(ConfigError::InvalidTargetDir(format!(
+                "Failed to canonicalize target directory '{}': {}",
+                display, source
+            )))
+        },
+        RustowError::Fs(fs_error) => RustowError::Config(ConfigError::InvalidTargetDir(format!(
+            "Failed to canonicalize target directory '{}': {}",
+            display, fs_error
+        ))),
+        _ => RustowError::Config(ConfigError::InvalidTargetDir(format!(
+            "An unexpected error occurred while canonicalizing target directory '{}': {}",
+            display, e
+        ))),
+    })
+}
+
+fn compile_regex_patterns(patterns: &[String], option_label: &str) -> RustowResult<Vec<Regex>> {
+    patterns
+        .iter()
+        .map(|pattern| {
+            Regex::new(pattern).map_err(|e| {
+                RustowError::Config(ConfigError::InvalidRegexPattern(format!(
+                    "Invalid {} pattern '{}': {}",
+                    option_label, pattern, e
+                )))
+            })
+        })
+        .collect()
 }
 
 fn display_parent(display: &str) -> Option<String> {

--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,0 +1,480 @@
+use crate::cli::PathDisplayOverride;
+use crate::config::Config;
+use crate::error::{ConfigError, FsError, IgnoreError, RustowError, StowError};
+use crate::stow::{TargetActionReport, TargetActionReportStatus};
+use std::borrow::Cow;
+use std::path::{Path, PathBuf};
+
+pub(crate) struct RedactionTable {
+    replacements: Vec<(String, String)>,
+}
+
+impl RedactionTable {
+    pub(crate) fn new(path_displays: &[PathDisplayOverride]) -> Self {
+        let mut replacements: Vec<(String, String)> = Vec::new();
+        for override_path in path_displays {
+            if let Some((path, display)) = {
+                let path = override_path.path.display().to_string();
+                if path.is_empty()
+                    || path == override_path.display
+                    || is_bare_relative_redaction_path(&override_path.path)
+                {
+                    None
+                } else {
+                    Some((path, override_path.display.clone()))
+                }
+            } {
+                add_redaction_replacement(&mut replacements, path.clone(), display.clone());
+                let debug_path = debug_path_fragment(&override_path.path);
+                let debug_display = debug_string_fragment(&display);
+                add_redaction_replacement(&mut replacements, debug_path, debug_display);
+            }
+        }
+        replacements.sort_by(|(left, _), (right, _)| right.len().cmp(&left.len()));
+
+        Self { replacements }
+    }
+
+    pub(crate) fn redact<'a>(&self, text: &'a str) -> Cow<'a, str> {
+        if self.replacements.is_empty() {
+            return Cow::Borrowed(text);
+        }
+
+        self.replacements
+            .iter()
+            .fold(Cow::Borrowed(text), |redacted, (path, display)| {
+                replace_path_occurrences(redacted, path, display)
+            })
+    }
+
+    fn redact_path(&self, path: PathBuf) -> PathBuf {
+        let display = path.display().to_string();
+        let redacted = self.redact(&display);
+        if redacted.as_ref() == display {
+            path
+        } else {
+            PathBuf::from(redacted.into_owned())
+        }
+    }
+}
+
+pub(crate) fn process_reports(
+    reports: &[TargetActionReport],
+    config: &Config,
+    path_displays: &[PathDisplayOverride],
+) {
+    let redactions = RedactionTable::new(path_displays);
+
+    if reports.is_empty() {
+        if config.verbosity > 0 {
+            eprintln!("No actions to perform.");
+        }
+        return;
+    }
+
+    for report in reports {
+        match &report.status {
+            TargetActionReportStatus::Success => {
+                if config.verbosity > 1 || config.simulate {
+                    if let Some(message) = &report.message {
+                        eprintln!("{}", redactions.redact(message));
+                    }
+                }
+            },
+            TargetActionReportStatus::Skipped => {
+                if config.verbosity > 0 || config.simulate {
+                    if let Some(message) = &report.message {
+                        eprintln!("{}", redactions.redact(message));
+                    }
+                }
+            },
+            TargetActionReportStatus::ConflictPrevented => {
+                if let Some(message) = &report.message {
+                    eprintln!("{}", redactions.redact(message));
+                }
+            },
+            TargetActionReportStatus::Failure(error) => {
+                eprintln!("ERROR: {}", redactions.redact(error));
+                if let Some(message) = &report.message {
+                    eprintln!("Details: {}", redactions.redact(message));
+                }
+            },
+        }
+    }
+
+    if config.verbosity > 0 || config.simulate {
+        let success_count = reports
+            .iter()
+            .filter(|report| matches!(report.status, TargetActionReportStatus::Success))
+            .count();
+        let skipped_count = reports
+            .iter()
+            .filter(|report| matches!(report.status, TargetActionReportStatus::Skipped))
+            .count();
+        let conflict_count = reports
+            .iter()
+            .filter(|report| matches!(report.status, TargetActionReportStatus::ConflictPrevented))
+            .count();
+        let failure_count = reports
+            .iter()
+            .filter(|report| matches!(report.status, TargetActionReportStatus::Failure(_)))
+            .count();
+
+        eprintln!(
+            "\nSummary: {} successful, {} skipped, {} conflicts, {} failures",
+            success_count, skipped_count, conflict_count, failure_count
+        );
+    }
+}
+
+fn add_redaction_replacement(
+    replacements: &mut Vec<(String, String)>,
+    path: String,
+    display: String,
+) {
+    if !path.is_empty()
+        && path != display
+        && !replacements.iter().any(|(needle, _)| needle == &path)
+    {
+        replacements.push((path, display));
+    }
+}
+
+fn debug_path_fragment(path: &Path) -> String {
+    unquote_debug_fragment(&format!("{:?}", path))
+}
+
+fn debug_string_fragment(value: &str) -> String {
+    unquote_debug_fragment(&format!("{:?}", value))
+}
+
+fn unquote_debug_fragment(value: &str) -> String {
+    value
+        .strip_prefix('"')
+        .and_then(|value| value.strip_suffix('"'))
+        .unwrap_or(value)
+        .to_string()
+}
+
+fn is_bare_relative_redaction_path(path: &Path) -> bool {
+    path.is_relative() && path.components().count() == 1
+}
+
+fn replace_path_occurrences<'a>(
+    text: Cow<'a, str>,
+    needle: &str,
+    replacement: &str,
+) -> Cow<'a, str> {
+    let source = text.as_ref();
+    let mut output: Option<String> = None;
+    let mut copied_until = 0;
+    let mut search_start = 0;
+
+    while let Some(relative_index) = source[search_start..].find(needle) {
+        let index = search_start + relative_index;
+        let end = index + needle.len();
+
+        if is_path_boundary_before(source, index) && is_path_boundary_after(source, end) {
+            let output = output.get_or_insert_with(|| String::with_capacity(source.len()));
+            output.push_str(&source[copied_until..index]);
+            output.push_str(replacement);
+            copied_until = end;
+        }
+
+        search_start = end;
+    }
+
+    match output {
+        Some(mut output) => {
+            output.push_str(&source[copied_until..]);
+            Cow::Owned(output)
+        },
+        None => text,
+    }
+}
+
+fn is_path_boundary_before(text: &str, index: usize) -> bool {
+    match text[..index].chars().next_back() {
+        Some(ch) => is_path_boundary_char(ch),
+        None => true,
+    }
+}
+
+fn is_path_boundary_after(text: &str, index: usize) -> bool {
+    match text[index..].chars().next() {
+        Some(ch) => is_path_boundary_char(ch),
+        None => true,
+    }
+}
+
+fn is_path_boundary_char(ch: char) -> bool {
+    matches!(
+        ch,
+        '/' | '\\'
+            | '"'
+            | '\''
+            | '('
+            | ')'
+            | '['
+            | ']'
+            | '{'
+            | '}'
+            | ','
+            | ':'
+            | ';'
+            | ' '
+            | '\n'
+            | '\t'
+    )
+}
+
+pub(crate) fn redact_runtime_error(
+    error: RustowError,
+    path_displays: &[PathDisplayOverride],
+) -> RustowError {
+    let redactions = RedactionTable::new(path_displays);
+    redact_rustow_error(error, &redactions)
+}
+
+fn redact_owned_string(value: String, redactions: &RedactionTable) -> String {
+    match redactions.redact(&value) {
+        Cow::Borrowed(_) => value,
+        Cow::Owned(redacted) => redacted,
+    }
+}
+
+fn redact_rustow_error(error: RustowError, redactions: &RedactionTable) -> RustowError {
+    match error {
+        RustowError::Config(error) => RustowError::Config(redact_config_error(error, redactions)),
+        RustowError::Stow(error) => RustowError::Stow(redact_stow_error(error, redactions)),
+        RustowError::Fs(error) => RustowError::Fs(redact_fs_error(error, redactions)),
+        RustowError::Ignore(error) => RustowError::Ignore(redact_ignore_error(error, redactions)),
+        RustowError::Cli(message) => RustowError::Cli(redact_owned_string(message, redactions)),
+        RustowError::InvalidPattern(pattern) => {
+            RustowError::InvalidPattern(redact_owned_string(pattern, redactions))
+        },
+        RustowError::Io(error) => RustowError::Io(error),
+        RustowError::Regex(error) => RustowError::Regex(error),
+    }
+}
+
+fn redact_config_error(error: ConfigError, redactions: &RedactionTable) -> ConfigError {
+    match error {
+        ConfigError::InvalidTargetDir(message) => {
+            ConfigError::InvalidTargetDir(redact_owned_string(message, redactions))
+        },
+        ConfigError::InvalidStowDir(message) => {
+            ConfigError::InvalidStowDir(redact_owned_string(message, redactions))
+        },
+        ConfigError::InvalidPackageName(message) => {
+            ConfigError::InvalidPackageName(redact_owned_string(message, redactions))
+        },
+        ConfigError::InvalidRegexPattern(message) => {
+            ConfigError::InvalidRegexPattern(redact_owned_string(message, redactions))
+        },
+        ConfigError::InvalidOperation(message) => {
+            ConfigError::InvalidOperation(redact_owned_string(message, redactions))
+        },
+        ConfigError::InvalidVerbosityLevel(level) => ConfigError::InvalidVerbosityLevel(level),
+    }
+}
+
+fn redact_stow_error(error: StowError, redactions: &RedactionTable) -> StowError {
+    match error {
+        StowError::Conflict(message) => {
+            StowError::Conflict(redact_owned_string(message, redactions))
+        },
+        StowError::PackageNotFound(package) => {
+            StowError::PackageNotFound(redact_owned_string(package, redactions))
+        },
+        StowError::InvalidPackageStructure(message) => {
+            StowError::InvalidPackageStructure(redact_owned_string(message, redactions))
+        },
+        StowError::OperationFailed(message) => {
+            StowError::OperationFailed(redact_owned_string(message, redactions))
+        },
+    }
+}
+
+fn redact_ignore_error(error: IgnoreError, redactions: &RedactionTable) -> IgnoreError {
+    match error {
+        IgnoreError::LoadPatternsError(message) => {
+            IgnoreError::LoadPatternsError(redact_owned_string(message, redactions))
+        },
+        IgnoreError::InvalidPattern(pattern) => {
+            IgnoreError::InvalidPattern(redact_owned_string(pattern, redactions))
+        },
+    }
+}
+
+fn redact_fs_error(error: FsError, redactions: &RedactionTable) -> FsError {
+    match error {
+        FsError::Io { path, source } => FsError::Io {
+            path: redactions.redact_path(path),
+            source,
+        },
+        FsError::Canonicalize { path, source } => FsError::Canonicalize {
+            path: redactions.redact_path(path),
+            source,
+        },
+        FsError::NotFound(path) => FsError::NotFound(redactions.redact_path(path)),
+        FsError::NotADirectory(path) => FsError::NotADirectory(redactions.redact_path(path)),
+        FsError::NotASymlink(path) => FsError::NotASymlink(redactions.redact_path(path)),
+        FsError::CreateSymlink {
+            link_path,
+            target_path,
+            source,
+        } => FsError::CreateSymlink {
+            link_path: redactions.redact_path(link_path),
+            target_path: redactions.redact_path(target_path),
+            source,
+        },
+        FsError::ReadSymlink { path, source } => FsError::ReadSymlink {
+            path: redactions.redact_path(path),
+            source,
+        },
+        FsError::DeleteSymlink { path, source } => FsError::DeleteSymlink {
+            path: redactions.redact_path(path),
+            source,
+        },
+        FsError::CreateDirectory { path, source } => FsError::CreateDirectory {
+            path: redactions.redact_path(path),
+            source,
+        },
+        FsError::DeleteDirectory { path, source } => FsError::DeleteDirectory {
+            path: redactions.redact_path(path),
+            source,
+        },
+        FsError::MoveItem {
+            source_path,
+            destination_path,
+            source_io_error,
+        } => FsError::MoveItem {
+            source_path: redactions.redact_path(source_path),
+            destination_path: redactions.redact_path(destination_path),
+            source_io_error,
+        },
+        FsError::MoveSamePath(path) => FsError::MoveSamePath(redactions.redact_path(path)),
+        FsError::WalkDir { path, source } => FsError::WalkDir {
+            path: redactions.redact_path(path),
+            source,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cli::Args;
+    use std::fs;
+    use tempfile::tempdir;
+
+    struct CurrentDirGuard {
+        original: PathBuf,
+    }
+
+    impl CurrentDirGuard {
+        fn set(path: &Path) -> Self {
+            let original = std::env::current_dir().unwrap();
+            std::env::set_current_dir(path).unwrap();
+            Self { original }
+        }
+    }
+
+    impl Drop for CurrentDirGuard {
+        fn drop(&mut self) {
+            std::env::set_current_dir(&self.original).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_replace_path_occurrences_requires_leading_boundary() {
+        let text = "real: /tmp/secret/file; unrelated: /backup/tmp/secret/file";
+
+        assert_eq!(
+            replace_path_occurrences(Cow::Borrowed(text), "/tmp/secret", "$RUSTOW_SECRET"),
+            "real: $RUSTOW_SECRET/file; unrelated: /backup/tmp/secret/file"
+        );
+    }
+
+    #[test]
+    fn test_redaction_table_ignores_bare_relative_paths() {
+        let redactions = RedactionTable::new(&[PathDisplayOverride::new(
+            PathBuf::from("stow"),
+            "$RUSTOW_STOW_DIR".to_string(),
+        )]);
+
+        assert_eq!(
+            redactions
+                .redact("Failed to canonicalize stow directory '$RUSTOW_STOW_DIR'")
+                .as_ref(),
+            "Failed to canonicalize stow directory '$RUSTOW_STOW_DIR'"
+        );
+    }
+
+    #[test]
+    fn test_redaction_table_borrows_when_no_replacements_apply() {
+        let redactions = RedactionTable::new(&[]);
+        let redacted = redactions.redact("No path redaction needed");
+
+        assert!(matches!(redacted, Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn test_redact_owned_string_returns_original_allocation_when_unchanged() {
+        let redactions = RedactionTable::new(&[PathDisplayOverride::new(
+            PathBuf::from("/tmp/secret"),
+            "$RUSTOW_SECRET".to_string(),
+        )]);
+        let message = "No matching path".to_string();
+        let original_ptr = message.as_ptr();
+        let redacted = redact_owned_string(message, &redactions);
+
+        assert_eq!(redacted.as_ptr(), original_ptr);
+    }
+
+    #[test]
+    fn test_redaction_table_keeps_relative_paths_with_separators() {
+        let redactions = RedactionTable::new(&[PathDisplayOverride::new(
+            PathBuf::from("secret/stow"),
+            "$RUSTOW_STOW_DIR".to_string(),
+        )]);
+
+        assert_eq!(
+            redactions.redact("Path secret/stow/pkg is hidden").as_ref(),
+            "Path $RUSTOW_STOW_DIR/pkg is hidden"
+        );
+    }
+
+    #[test]
+    fn test_redaction_table_replaces_debug_escaped_paths() {
+        let secret_path = PathBuf::from("/tmp/secret\\root/stow");
+        let redactions = RedactionTable::new(&[PathDisplayOverride::new(
+            secret_path.clone(),
+            "$RUSTOW_SECRET_ROOT/stow".to_string(),
+        )]);
+        let message = format!("SIMULATE: target {:?}", secret_path.join("pkg/bin/tool"));
+        let redacted = redactions.redact(&message);
+
+        assert!(!redacted.contains("secret\\\\root"));
+        assert!(redacted.contains("$RUSTOW_SECRET_ROOT/stow/pkg/bin/tool"));
+    }
+
+    #[test]
+    fn test_public_run_keeps_returned_error_paths_unredacted() {
+        let _lock = crate::test_sync::IsolatedProcessEnv::new();
+        let temp_dir = tempdir().unwrap();
+        let stow_dir = temp_dir.path().join("stow");
+        let target_dir = temp_dir.path().join("target");
+        fs::create_dir_all(&stow_dir).unwrap();
+        fs::create_dir_all(&target_dir).unwrap();
+        fs::write(stow_dir.join("pkg"), "not a directory").unwrap();
+        let _cwd_guard = CurrentDirGuard::set(temp_dir.path());
+
+        let args = Args::parse_from(["rustow", "-d", "stow", "-t", "target", "pkg"]);
+        let error = crate::run(args).unwrap_err().to_string();
+
+        assert!(error.contains(stow_dir.join("pkg").to_string_lossy().as_ref()));
+        assert!(!error.contains("\"stow/pkg\""));
+    }
+}

--- a/src/dotfiles.rs
+++ b/src/dotfiles.rs
@@ -1,4 +1,3 @@
-#[allow(dead_code)] // Allow dead code for this function as it will be used by other modules later
 pub fn process_item_name(item_name: &str, is_dotfiles_enabled: bool) -> String {
     if !is_dotfiles_enabled {
         return item_name.to_string();

--- a/src/fs_utils.rs
+++ b/src/fs_utils.rs
@@ -1,4 +1,5 @@
 use crate::error::{FsError, Result, RustowError};
+use crate::path_utils::normalize_path_components;
 use std::path::{Path, PathBuf};
 use walkdir::WalkDir;
 
@@ -206,25 +207,26 @@ pub fn walk_package_dir(package_path: &Path) -> Result<Vec<RawStowItem>> {
     let mut items: Vec<RawStowItem> = Vec::new();
 
     for entry_result in WalkDir::new(package_path).min_depth(1) {
-        // entry_result の型は walkdir::Result<walkdir::DirEntry>
         let entry: walkdir::DirEntry = entry_result.map_err(|e| FsError::WalkDir {
-            // 型を明示
-            path: e.path().unwrap_or(package_path).to_path_buf(), // Use package_path if entry path is not available
+            path: e.path().unwrap_or(package_path).to_path_buf(),
             source: e
                 .into_io_error()
                 .unwrap_or_else(|| std::io::Error::new(std::io::ErrorKind::Other, "walkdir error")),
         })?;
 
-        let absolute_path: PathBuf = entry.path().to_path_buf(); // 型を明示
-        let package_relative_path: PathBuf = absolute_path.strip_prefix(package_path) // 型を明示
-            .map_err(|_| RustowError::Stow(crate::error::StowError::InvalidPackageStructure(
-                format!("Failed to strip prefix for {:?} from {:?}", absolute_path, package_path)
-            )))?
+        let absolute_path: PathBuf = entry.path().to_path_buf();
+        let package_relative_path: PathBuf = absolute_path
+            .strip_prefix(package_path)
+            .map_err(|_| {
+                RustowError::Stow(crate::error::StowError::InvalidPackageStructure(format!(
+                    "Failed to strip prefix for {:?} from {:?}",
+                    absolute_path, package_path
+                )))
+            })?
             .to_path_buf();
 
-        let file_type: std::fs::FileType = entry.file_type(); // 型を明示
+        let file_type: std::fs::FileType = entry.file_type();
         let item_type: RawStowItemType = if file_type.is_symlink() {
-            // 型を明示
             RawStowItemType::Symlink
         } else if file_type.is_dir() {
             RawStowItemType::Directory
@@ -255,7 +257,6 @@ pub fn is_stow_symlink(
 
     // 2. Canonicalize stow_dir for reliable comparison and to surface missing/invalid paths
     let canonical_stow_dir: PathBuf = match canonicalize_path(stow_dir) {
-        // 型を明示
         Ok(p) => p,
         Err(RustowError::Fs(FsError::Canonicalize { path, source })) => {
             // Propagate canonicalization error for stow_dir
@@ -277,14 +278,13 @@ pub fn is_stow_symlink(
     // 3. Read the link's destination
     // read_link itself returns Err if not a symlink, but we've already checked.
     let target_dest_path_from_link: PathBuf = match read_link(link_path) {
-        // 型を明示
         Ok(p) => p,
         Err(RustowError::Fs(FsError::NotASymlink(_))) => return Ok(None), // Should be caught by is_symlink above
         Err(e) => return Err(e),
     };
 
     // 4. Resolve the link's destination to an absolute path (without following symlinks)
-    let link_parent_dir: &Path = link_path.parent().unwrap_or_else(|| Path::new("")); // 型を明示
+    let link_parent_dir: &Path = link_path.parent().unwrap_or_else(|| Path::new(""));
 
     let potentially_non_canonical_target_abs_path = if target_dest_path_from_link.is_absolute() {
         target_dest_path_from_link
@@ -335,26 +335,6 @@ pub fn is_stow_symlink(
             Ok(None)
         },
     }
-}
-
-fn normalize_path_components(path: &Path) -> PathBuf {
-    let mut normalized_components = Vec::new();
-
-    for component in path.components() {
-        match component {
-            std::path::Component::ParentDir => {
-                normalized_components.pop();
-            },
-            std::path::Component::CurDir => {
-                // Skip current directory components
-            },
-            other => {
-                normalized_components.push(other);
-            },
-        }
-    }
-
-    normalized_components.iter().collect()
 }
 
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,13 @@
 pub mod cli;
 pub mod config;
+mod diagnostics;
 pub mod dotfiles;
 pub mod error;
 pub mod fs_utils;
 pub mod ignore;
+mod path_utils;
 pub mod stow;
+mod stow_types;
 #[cfg(test)]
 mod test_sync;
 
@@ -12,13 +15,12 @@ use crate::cli::{
     Args, OperationGroup, OperationMode, ParsedArgs, PathDisplayOverride, RuntimeParsedArgs,
 };
 use crate::config::{Config, PackageOperation, StowMode};
-use crate::error::{ConfigError, FsError, IgnoreError, RustowError, StowError};
+use crate::error::{ConfigError, RustowError, StowError};
 use crate::stow::{
     delete_packages, mixed_packages, restow_packages, stow_packages,
     validate_package_for_operation_with_display,
 };
-use std::borrow::Cow;
-use std::path::{Component, Path, PathBuf};
+use std::path::{Component, Path};
 
 /// Runs the rustow application logic.
 pub fn run(args: Args) -> Result<(), RustowError> {
@@ -65,15 +67,12 @@ fn run_with_operation_groups_and_path_displays(
     redact_diagnostics: bool,
 ) -> Result<(), RustowError> {
     let result = (|| {
-        // eprintln!("stderr: Successfully parsed args in lib::run: {:?}", args.clone());
         if operation_groups.is_empty() {
             reject_ambiguous_mixed_args(&args)?;
         }
 
         match Config::from_args_with_path_displays(args, &mut path_displays) {
             Ok(config) => {
-                // eprintln!("stderr: Successfully constructed config in lib::run: {:?}", config);
-
                 path_displays.push(PathDisplayOverride::new(
                     config.home_dir.join(".stow-global-ignore"),
                     "~/.stow-global-ignore".to_string(),
@@ -93,7 +92,7 @@ fn run_with_operation_groups_and_path_displays(
                 let reports = execute_config_operations(&config, &package_operations)?;
 
                 // Process reports for logging/output
-                process_reports(&reports, &config, diagnostic_path_displays);
+                diagnostics::process_reports(&reports, &config, diagnostic_path_displays);
 
                 let conflict_count = reports
                     .iter()
@@ -120,15 +119,12 @@ fn run_with_operation_groups_and_path_displays(
 
                 Ok(())
             },
-            Err(e) => {
-                // eprintln!("stderr: Error constructing config in lib::run: {}", e);
-                Err(e)
-            },
+            Err(e) => Err(e),
         }
     })();
 
     if redact_diagnostics {
-        result.map_err(|error| redact_runtime_error(error, &path_displays))
+        result.map_err(|error| diagnostics::redact_runtime_error(error, &path_displays))
     } else {
         result
     }
@@ -280,488 +276,5 @@ fn execute_operation_group(
 }
 
 fn reports_have_blocking_status(reports: &[crate::stow::TargetActionReport]) -> bool {
-    reports.iter().any(|report| {
-        matches!(
-            report.status,
-            crate::stow::TargetActionReportStatus::ConflictPrevented
-                | crate::stow::TargetActionReportStatus::Failure(_)
-        )
-    })
-}
-
-/// Process and display action reports based on verbosity and simulation settings
-fn process_reports(
-    reports: &[crate::stow::TargetActionReport],
-    config: &Config,
-    path_displays: &[PathDisplayOverride],
-) {
-    let redactions = RedactionTable::new(path_displays);
-
-    if reports.is_empty() {
-        if config.verbosity > 0 {
-            eprintln!("No actions to perform.");
-        }
-        return;
-    }
-
-    for report in reports {
-        match &report.status {
-            crate::stow::TargetActionReportStatus::Success => {
-                if config.verbosity > 1 || config.simulate {
-                    if let Some(message) = &report.message {
-                        eprintln!("{}", redactions.redact(message));
-                    }
-                }
-            },
-            crate::stow::TargetActionReportStatus::Skipped => {
-                if config.verbosity > 0 || config.simulate {
-                    if let Some(message) = &report.message {
-                        eprintln!("{}", redactions.redact(message));
-                    }
-                }
-            },
-            crate::stow::TargetActionReportStatus::ConflictPrevented => {
-                if let Some(message) = &report.message {
-                    eprintln!("{}", redactions.redact(message));
-                }
-            },
-            crate::stow::TargetActionReportStatus::Failure(error) => {
-                eprintln!("ERROR: {}", redactions.redact(error));
-                if let Some(message) = &report.message {
-                    eprintln!("Details: {}", redactions.redact(message));
-                }
-            },
-        }
-    }
-
-    // Summary
-    if config.verbosity > 0 || config.simulate {
-        let success_count = reports
-            .iter()
-            .filter(|r| matches!(r.status, crate::stow::TargetActionReportStatus::Success))
-            .count();
-        let skipped_count = reports
-            .iter()
-            .filter(|r| matches!(r.status, crate::stow::TargetActionReportStatus::Skipped))
-            .count();
-        let conflict_count = reports
-            .iter()
-            .filter(|r| {
-                matches!(
-                    r.status,
-                    crate::stow::TargetActionReportStatus::ConflictPrevented
-                )
-            })
-            .count();
-        let failure_count = reports
-            .iter()
-            .filter(|r| matches!(r.status, crate::stow::TargetActionReportStatus::Failure(_)))
-            .count();
-
-        eprintln!(
-            "\nSummary: {} successful, {} skipped, {} conflicts, {} failures",
-            success_count, skipped_count, conflict_count, failure_count
-        );
-    }
-}
-
-struct RedactionTable {
-    replacements: Vec<(String, String)>,
-}
-
-impl RedactionTable {
-    fn new(path_displays: &[PathDisplayOverride]) -> Self {
-        let mut replacements: Vec<(String, String)> = Vec::new();
-        for override_path in path_displays {
-            if let Some((path, display)) = {
-                let path = override_path.path.display().to_string();
-                if path.is_empty()
-                    || path == override_path.display
-                    || is_bare_relative_redaction_path(&override_path.path)
-                {
-                    None
-                } else {
-                    Some((path, override_path.display.clone()))
-                }
-            } {
-                add_redaction_replacement(&mut replacements, path.clone(), display.clone());
-                let debug_path = debug_path_fragment(&override_path.path);
-                let debug_display = debug_string_fragment(&display);
-                add_redaction_replacement(&mut replacements, debug_path, debug_display);
-            }
-        }
-        replacements.sort_by(|(left, _), (right, _)| right.len().cmp(&left.len()));
-
-        Self { replacements }
-    }
-
-    fn redact<'a>(&self, text: &'a str) -> Cow<'a, str> {
-        if self.replacements.is_empty() {
-            return Cow::Borrowed(text);
-        }
-
-        self.replacements
-            .iter()
-            .fold(Cow::Borrowed(text), |redacted, (path, display)| {
-                replace_path_occurrences(redacted, path, display)
-            })
-    }
-
-    fn redact_path(&self, path: PathBuf) -> PathBuf {
-        let display = path.display().to_string();
-        let redacted = self.redact(&display);
-        if redacted.as_ref() == display {
-            path
-        } else {
-            PathBuf::from(redacted.into_owned())
-        }
-    }
-}
-
-fn add_redaction_replacement(
-    replacements: &mut Vec<(String, String)>,
-    path: String,
-    display: String,
-) {
-    if !path.is_empty()
-        && path != display
-        && !replacements.iter().any(|(needle, _)| needle == &path)
-    {
-        replacements.push((path, display));
-    }
-}
-
-fn debug_path_fragment(path: &Path) -> String {
-    unquote_debug_fragment(&format!("{:?}", path))
-}
-
-fn debug_string_fragment(value: &str) -> String {
-    unquote_debug_fragment(&format!("{:?}", value))
-}
-
-fn unquote_debug_fragment(value: &str) -> String {
-    value
-        .strip_prefix('"')
-        .and_then(|value| value.strip_suffix('"'))
-        .unwrap_or(value)
-        .to_string()
-}
-
-fn is_bare_relative_redaction_path(path: &Path) -> bool {
-    path.is_relative() && path.components().count() == 1
-}
-
-fn replace_path_occurrences<'a>(
-    text: Cow<'a, str>,
-    needle: &str,
-    replacement: &str,
-) -> Cow<'a, str> {
-    let source = text.as_ref();
-    let mut output: Option<String> = None;
-    let mut copied_until = 0;
-    let mut search_start = 0;
-
-    while let Some(relative_index) = source[search_start..].find(needle) {
-        let index = search_start + relative_index;
-        let end = index + needle.len();
-
-        if is_path_boundary_before(source, index) && is_path_boundary_after(source, end) {
-            let output = output.get_or_insert_with(|| String::with_capacity(source.len()));
-            output.push_str(&source[copied_until..index]);
-            output.push_str(replacement);
-            copied_until = end;
-        }
-
-        search_start = end;
-    }
-
-    match output {
-        Some(mut output) => {
-            output.push_str(&source[copied_until..]);
-            Cow::Owned(output)
-        },
-        None => text,
-    }
-}
-
-fn is_path_boundary_before(text: &str, index: usize) -> bool {
-    match text[..index].chars().next_back() {
-        Some(ch) => is_path_boundary_char(ch),
-        None => true,
-    }
-}
-
-fn is_path_boundary_after(text: &str, index: usize) -> bool {
-    match text[index..].chars().next() {
-        Some(ch) => is_path_boundary_char(ch),
-        None => true,
-    }
-}
-
-fn is_path_boundary_char(ch: char) -> bool {
-    matches!(
-        ch,
-        '/' | '\\'
-            | '"'
-            | '\''
-            | '('
-            | ')'
-            | '['
-            | ']'
-            | '{'
-            | '}'
-            | ','
-            | ':'
-            | ';'
-            | ' '
-            | '\n'
-            | '\t'
-    )
-}
-
-fn redact_runtime_error(error: RustowError, path_displays: &[PathDisplayOverride]) -> RustowError {
-    let redactions = RedactionTable::new(path_displays);
-    redact_rustow_error(error, &redactions)
-}
-
-fn redact_owned_string(value: String, redactions: &RedactionTable) -> String {
-    match redactions.redact(&value) {
-        Cow::Borrowed(_) => value,
-        Cow::Owned(redacted) => redacted,
-    }
-}
-
-fn redact_rustow_error(error: RustowError, redactions: &RedactionTable) -> RustowError {
-    match error {
-        RustowError::Config(error) => RustowError::Config(redact_config_error(error, redactions)),
-        RustowError::Stow(error) => RustowError::Stow(redact_stow_error(error, redactions)),
-        RustowError::Fs(error) => RustowError::Fs(redact_fs_error(error, redactions)),
-        RustowError::Ignore(error) => RustowError::Ignore(redact_ignore_error(error, redactions)),
-        RustowError::Cli(message) => RustowError::Cli(redact_owned_string(message, redactions)),
-        RustowError::InvalidPattern(pattern) => {
-            RustowError::InvalidPattern(redact_owned_string(pattern, redactions))
-        },
-        RustowError::Io(error) => RustowError::Io(error),
-        RustowError::Regex(error) => RustowError::Regex(error),
-    }
-}
-
-fn redact_config_error(error: ConfigError, redactions: &RedactionTable) -> ConfigError {
-    match error {
-        ConfigError::InvalidTargetDir(message) => {
-            ConfigError::InvalidTargetDir(redact_owned_string(message, redactions))
-        },
-        ConfigError::InvalidStowDir(message) => {
-            ConfigError::InvalidStowDir(redact_owned_string(message, redactions))
-        },
-        ConfigError::InvalidPackageName(message) => {
-            ConfigError::InvalidPackageName(redact_owned_string(message, redactions))
-        },
-        ConfigError::InvalidRegexPattern(message) => {
-            ConfigError::InvalidRegexPattern(redact_owned_string(message, redactions))
-        },
-        ConfigError::InvalidOperation(message) => {
-            ConfigError::InvalidOperation(redact_owned_string(message, redactions))
-        },
-        ConfigError::InvalidVerbosityLevel(level) => ConfigError::InvalidVerbosityLevel(level),
-    }
-}
-
-fn redact_stow_error(error: StowError, redactions: &RedactionTable) -> StowError {
-    match error {
-        StowError::Conflict(message) => {
-            StowError::Conflict(redact_owned_string(message, redactions))
-        },
-        StowError::PackageNotFound(package) => {
-            StowError::PackageNotFound(redact_owned_string(package, redactions))
-        },
-        StowError::InvalidPackageStructure(message) => {
-            StowError::InvalidPackageStructure(redact_owned_string(message, redactions))
-        },
-        StowError::OperationFailed(message) => {
-            StowError::OperationFailed(redact_owned_string(message, redactions))
-        },
-    }
-}
-
-fn redact_ignore_error(error: IgnoreError, redactions: &RedactionTable) -> IgnoreError {
-    match error {
-        IgnoreError::LoadPatternsError(message) => {
-            IgnoreError::LoadPatternsError(redact_owned_string(message, redactions))
-        },
-        IgnoreError::InvalidPattern(pattern) => {
-            IgnoreError::InvalidPattern(redact_owned_string(pattern, redactions))
-        },
-    }
-}
-
-fn redact_fs_error(error: FsError, redactions: &RedactionTable) -> FsError {
-    match error {
-        FsError::Io { path, source } => FsError::Io {
-            path: redactions.redact_path(path),
-            source,
-        },
-        FsError::Canonicalize { path, source } => FsError::Canonicalize {
-            path: redactions.redact_path(path),
-            source,
-        },
-        FsError::NotFound(path) => FsError::NotFound(redactions.redact_path(path)),
-        FsError::NotADirectory(path) => FsError::NotADirectory(redactions.redact_path(path)),
-        FsError::NotASymlink(path) => FsError::NotASymlink(redactions.redact_path(path)),
-        FsError::CreateSymlink {
-            link_path,
-            target_path,
-            source,
-        } => FsError::CreateSymlink {
-            link_path: redactions.redact_path(link_path),
-            target_path: redactions.redact_path(target_path),
-            source,
-        },
-        FsError::ReadSymlink { path, source } => FsError::ReadSymlink {
-            path: redactions.redact_path(path),
-            source,
-        },
-        FsError::DeleteSymlink { path, source } => FsError::DeleteSymlink {
-            path: redactions.redact_path(path),
-            source,
-        },
-        FsError::CreateDirectory { path, source } => FsError::CreateDirectory {
-            path: redactions.redact_path(path),
-            source,
-        },
-        FsError::DeleteDirectory { path, source } => FsError::DeleteDirectory {
-            path: redactions.redact_path(path),
-            source,
-        },
-        FsError::MoveItem {
-            source_path,
-            destination_path,
-            source_io_error,
-        } => FsError::MoveItem {
-            source_path: redactions.redact_path(source_path),
-            destination_path: redactions.redact_path(destination_path),
-            source_io_error,
-        },
-        FsError::MoveSamePath(path) => FsError::MoveSamePath(redactions.redact_path(path)),
-        FsError::WalkDir { path, source } => FsError::WalkDir {
-            path: redactions.redact_path(path),
-            source,
-        },
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::fs;
-    use tempfile::tempdir;
-
-    struct CurrentDirGuard {
-        original: PathBuf,
-    }
-
-    impl CurrentDirGuard {
-        fn set(path: &Path) -> Self {
-            let original = std::env::current_dir().unwrap();
-            std::env::set_current_dir(path).unwrap();
-            Self { original }
-        }
-    }
-
-    impl Drop for CurrentDirGuard {
-        fn drop(&mut self) {
-            std::env::set_current_dir(&self.original).unwrap();
-        }
-    }
-
-    #[test]
-    fn test_replace_path_occurrences_requires_leading_boundary() {
-        let text = "real: /tmp/secret/file; unrelated: /backup/tmp/secret/file";
-
-        assert_eq!(
-            replace_path_occurrences(Cow::Borrowed(text), "/tmp/secret", "$RUSTOW_SECRET"),
-            "real: $RUSTOW_SECRET/file; unrelated: /backup/tmp/secret/file"
-        );
-    }
-
-    #[test]
-    fn test_redaction_table_ignores_bare_relative_paths() {
-        let redactions = RedactionTable::new(&[PathDisplayOverride::new(
-            PathBuf::from("stow"),
-            "$RUSTOW_STOW_DIR".to_string(),
-        )]);
-
-        assert_eq!(
-            redactions
-                .redact("Failed to canonicalize stow directory '$RUSTOW_STOW_DIR'")
-                .as_ref(),
-            "Failed to canonicalize stow directory '$RUSTOW_STOW_DIR'"
-        );
-    }
-
-    #[test]
-    fn test_redaction_table_borrows_when_no_replacements_apply() {
-        let redactions = RedactionTable::new(&[]);
-        let redacted = redactions.redact("No path redaction needed");
-
-        assert!(matches!(redacted, Cow::Borrowed(_)));
-    }
-
-    #[test]
-    fn test_redact_owned_string_returns_original_allocation_when_unchanged() {
-        let redactions = RedactionTable::new(&[PathDisplayOverride::new(
-            PathBuf::from("/tmp/secret"),
-            "$RUSTOW_SECRET".to_string(),
-        )]);
-        let message = "No matching path".to_string();
-        let original_ptr = message.as_ptr();
-        let redacted = redact_owned_string(message, &redactions);
-
-        assert_eq!(redacted.as_ptr(), original_ptr);
-    }
-
-    #[test]
-    fn test_redaction_table_keeps_relative_paths_with_separators() {
-        let redactions = RedactionTable::new(&[PathDisplayOverride::new(
-            PathBuf::from("secret/stow"),
-            "$RUSTOW_STOW_DIR".to_string(),
-        )]);
-
-        assert_eq!(
-            redactions.redact("Path secret/stow/pkg is hidden").as_ref(),
-            "Path $RUSTOW_STOW_DIR/pkg is hidden"
-        );
-    }
-
-    #[test]
-    fn test_redaction_table_replaces_debug_escaped_paths() {
-        let secret_path = PathBuf::from("/tmp/secret\\root/stow");
-        let redactions = RedactionTable::new(&[PathDisplayOverride::new(
-            secret_path.clone(),
-            "$RUSTOW_SECRET_ROOT/stow".to_string(),
-        )]);
-        let message = format!("SIMULATE: target {:?}", secret_path.join("pkg/bin/tool"));
-        let redacted = redactions.redact(&message);
-
-        assert!(!redacted.contains("secret\\\\root"));
-        assert!(redacted.contains("$RUSTOW_SECRET_ROOT/stow/pkg/bin/tool"));
-    }
-
-    #[test]
-    fn test_public_run_keeps_returned_error_paths_unredacted() {
-        let _lock = crate::test_sync::IsolatedProcessEnv::new();
-        let temp_dir = tempdir().unwrap();
-        let stow_dir = temp_dir.path().join("stow");
-        let target_dir = temp_dir.path().join("target");
-        fs::create_dir_all(&stow_dir).unwrap();
-        fs::create_dir_all(&target_dir).unwrap();
-        fs::write(stow_dir.join("pkg"), "not a directory").unwrap();
-        let _cwd_guard = CurrentDirGuard::set(temp_dir.path());
-
-        let args = Args::parse_from(["rustow", "-d", "stow", "-t", "target", "pkg"]);
-        let error = run(args).unwrap_err().to_string();
-
-        assert!(error.contains(stow_dir.join("pkg").to_string_lossy().as_ref()));
-        assert!(!error.contains("\"stow/pkg\""));
-    }
+    reports.iter().any(|report| report.status.is_blocking())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,28 +1,7 @@
-pub mod cli;
-pub mod config; // Enabled config module
-pub mod dotfiles;
-pub mod error;
-pub mod fs_utils;
-pub mod ignore;
-pub mod stow;
-#[cfg(test)]
-mod test_sync;
-
 use rustow::cli::Args;
 
 fn main() {
-    // Print all arguments received by main to stderr for debugging purposes.
-    // These can be removed or commented out in production.
-    // let all_args: Vec<String> = std::env::args().collect();
-    // eprintln!("stderr: main received args: {:?}", all_args);
-    // if all_args.len() == 1 && all_args[0].contains("rustow") {
-    //     eprintln!("stderr: Attempting to parse arguments for main binary execution context...");
-    // }
-    // let raw_cli_args: Vec<String> = std::env::args().collect();
-    // eprintln!("stderr: Raw CLI args (non-test execution): {:?}", raw_cli_args);
-
     let parsed_args = Args::parse_runtime_with_operation_groups();
-    // eprintln!("stderr: Successfully parsed args in main: {:?}", args.clone());
 
     if let Err(e) = rustow::run_runtime_parsed(parsed_args) {
         eprintln!("Error: {}", e);

--- a/src/path_utils.rs
+++ b/src/path_utils.rs
@@ -1,0 +1,59 @@
+use std::path::{Path, PathBuf};
+
+pub(crate) fn resolve_symlink_target(symlink_path: &Path, link_target: &Path) -> PathBuf {
+    if link_target.is_absolute() {
+        link_target.to_path_buf()
+    } else {
+        symlink_path
+            .parent()
+            .unwrap_or_else(|| Path::new(""))
+            .join(link_target)
+    }
+}
+
+pub(crate) fn normalize_path_components(path: &Path) -> PathBuf {
+    let mut normalized_components = Vec::new();
+
+    for component in path.components() {
+        match component {
+            std::path::Component::ParentDir => {
+                normalized_components.pop();
+            },
+            std::path::Component::CurDir => {},
+            other => {
+                normalized_components.push(other);
+            },
+        }
+    }
+
+    normalized_components.iter().collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resolve_symlink_target_keeps_absolute_target() {
+        assert_eq!(
+            resolve_symlink_target(Path::new("/tmp/link"), Path::new("/var/target")),
+            PathBuf::from("/var/target")
+        );
+    }
+
+    #[test]
+    fn test_resolve_symlink_target_joins_relative_target_to_link_parent() {
+        assert_eq!(
+            resolve_symlink_target(Path::new("/tmp/dir/link"), Path::new("../target")),
+            PathBuf::from("/tmp/dir/../target")
+        );
+    }
+
+    #[test]
+    fn test_normalize_path_components_collapses_dot_and_parent_components() {
+        assert_eq!(
+            normalize_path_components(Path::new("/tmp/dir/../target/./file")),
+            PathBuf::from("/tmp/target/file")
+        );
+    }
+}

--- a/src/stow.rs
+++ b/src/stow.rs
@@ -1,15 +1,12 @@
-// Placeholder for stow module
-// This file can be populated with stow logic later.
-
 use crate::config::Config;
 use crate::dotfiles;
 use crate::error::{FsError, RustowError, StowError};
 use crate::fs_utils::{self};
 use crate::ignore::{self, IgnorePatterns};
+use crate::path_utils::{normalize_path_components, resolve_symlink_target};
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-// Define modules inline for now
 mod conflict_resolver {
     use crate::stow::{ActionType, TargetAction};
     use std::collections::HashMap;
@@ -241,59 +238,11 @@ mod pattern_matcher {
     }
 }
 
+pub use crate::stow_types::{
+    ActionType, StowItem, StowItemType, TargetAction, TargetActionReport, TargetActionReportStatus,
+};
 use conflict_resolver::ConflictResolver;
 use pattern_matcher::PatternMatcher;
-
-// --- Action Planning Enums and Structs ---
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ActionType {
-    CreateSymlink,   // Create a symbolic link
-    DeleteSymlink,   // Delete a symbolic link
-    CreateDirectory, // Create a directory (for folding)
-    DeleteDirectory, // Delete an empty directory (during unstow)
-    AdoptFile,       // Move a file from target to stow dir, then link (for --adopt)
-    AdoptDirectory,  // Move a directory from target to stow dir, then link (for --adopt)
-    Skip,            // Skip an operation (e.g., due to --defer or already correct state)
-    Conflict,        // A conflict was detected that cannot be resolved by options
-                     // Maybe add more specific conflict types later if needed
-}
-
-// Re-define TargetAction based on the design document
-// The existing one in tests/integration_tests.rs is a placeholder.
-// We'll keep the existing one for now in stow.rs to avoid breaking tests immediately,
-// but we should aim to replace it or make it compatible.
-// For now, let's rename the existing one slightly to avoid direct collision if needed.
-// Actually, let's define the proper one here. Tests will need to adapt.
-
-#[derive(Debug, Clone)]
-pub struct TargetAction {
-    pub source_item: Option<StowItem>, // Original item from the package
-    pub target_path: PathBuf,          // Absolute path in the target directory
-    pub link_target_path: Option<PathBuf>, // Path the symlink should point to (relative to link's parent dir)
-    pub action_type: ActionType,
-    pub conflict_details: Option<String>, // Description of the conflict
-}
-
-// StowItem re-definition from design document
-// The existing one in tests/integration_tests.rs is a placeholder.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)] // Added PartialEq, Eq, Hash as per design doc
-pub enum StowItemType {
-    File,
-    Directory,
-    Symlink, // Represents a symlink within the package itself (less common for typical stow usage)
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)] // Added PartialEq, Eq, Hash
-pub struct StowItem {
-    pub package_relative_path: PathBuf, // Path relative to the package root (e.g., "bin/script", "dot-config/nvim/init.vim")
-    pub source_path: PathBuf,           // Absolute path to the item in the stow directory
-    pub item_type: StowItemType,        // Type of the item in the stow package
-    // Name of the item as it should appear in the target directory after dotfiles processing.
-    // For "file.txt", it's "file.txt". For "dot-bashrc" with --dotfiles, it's ".bashrc".
-    // For "dir/dot-foo", it's "dir/.foo".
-    pub target_name_after_dotfiles_processing: PathBuf,
-}
 
 fn plan_actions(
     package_name: &str,
@@ -1321,21 +1270,6 @@ fn is_parent_target_of_conflict(parent_path: &Path, all_actions: &[TargetAction]
     })
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum TargetActionReportStatus {
-    Success,
-    Skipped,           // For simulation or if no action was needed
-    ConflictPrevented, // For when a planned conflict action is "executed" (i.e. prevented)
-    Failure(String),   // Contains an error message
-}
-
-#[derive(Debug, Clone)]
-pub struct TargetActionReport {
-    pub original_action: TargetAction, // The action that was planned
-    pub status: TargetActionReportStatus,
-    pub message: Option<String>, // Additional details, e.g., error message or simulation output
-}
-
 fn execute_actions(
     actions: &[TargetAction],
     config: &Config,
@@ -2113,12 +2047,7 @@ where
 fn reports_allow_refolding(reports: &[TargetActionReport], config: &Config) -> bool {
     !config.simulate
         && !config.no_folding
-        && reports.iter().all(|report| {
-            !matches!(
-                report.status,
-                TargetActionReportStatus::ConflictPrevented | TargetActionReportStatus::Failure(_)
-            )
-        })
+        && reports.iter().all(|report| !report.status.is_blocking())
 }
 
 /// Execute a skip action
@@ -2857,39 +2786,6 @@ fn path_has_symlink_ancestor(path: &Path, root: &Path) -> bool {
     false
 }
 
-/// Resolve symlink target to absolute path
-fn resolve_symlink_target(symlink_path: &Path, link_target: &Path) -> PathBuf {
-    if link_target.is_absolute() {
-        link_target.to_path_buf()
-    } else {
-        symlink_path
-            .parent()
-            .unwrap_or_else(|| Path::new(""))
-            .join(link_target)
-    }
-}
-
-/// Normalize path by resolving .. and . components manually
-fn normalize_path_components(path: &Path) -> PathBuf {
-    let mut normalized_components = Vec::new();
-
-    for component in path.components() {
-        match component {
-            std::path::Component::ParentDir => {
-                normalized_components.pop();
-            },
-            std::path::Component::CurDir => {
-                // Skip current directory components
-            },
-            other => {
-                normalized_components.push(other);
-            },
-        }
-    }
-
-    normalized_components.iter().collect()
-}
-
 /// Check if a directory is empty
 fn is_directory_empty(dir_path: &Path) -> Result<bool, RustowError> {
     Ok(read_directory_entries(dir_path)?
@@ -3084,12 +2980,7 @@ fn validate_relative_package_name(package_name: &str) -> Result<(), RustowError>
 }
 
 fn target_action_reports_have_blocking_status(reports: &[TargetActionReport]) -> bool {
-    reports.iter().any(|report| {
-        matches!(
-            report.status,
-            TargetActionReportStatus::ConflictPrevented | TargetActionReportStatus::Failure(_)
-        )
-    })
+    reports.iter().any(|report| report.status.is_blocking())
 }
 
 /// Validate that the package path exists and is a directory

--- a/src/stow_types.rs
+++ b/src/stow_types.rs
@@ -1,0 +1,61 @@
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ActionType {
+    CreateSymlink,
+    DeleteSymlink,
+    CreateDirectory,
+    DeleteDirectory,
+    AdoptFile,
+    AdoptDirectory,
+    Skip,
+    Conflict,
+}
+
+#[derive(Debug, Clone)]
+pub struct TargetAction {
+    pub source_item: Option<StowItem>,
+    pub target_path: PathBuf,
+    pub link_target_path: Option<PathBuf>,
+    pub action_type: ActionType,
+    pub conflict_details: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum StowItemType {
+    File,
+    Directory,
+    Symlink,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StowItem {
+    pub package_relative_path: PathBuf,
+    pub source_path: PathBuf,
+    pub item_type: StowItemType,
+    pub target_name_after_dotfiles_processing: PathBuf,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TargetActionReportStatus {
+    Success,
+    Skipped,
+    ConflictPrevented,
+    Failure(String),
+}
+
+impl TargetActionReportStatus {
+    pub(crate) fn is_blocking(&self) -> bool {
+        matches!(
+            self,
+            TargetActionReportStatus::ConflictPrevented | TargetActionReportStatus::Failure(_)
+        )
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct TargetActionReport {
+    pub original_action: TargetAction,
+    pub status: TargetActionReportStatus,
+    pub message: Option<String>,
+}


### PR DESCRIPTION
## Summary

- Move runtime diagnostic redaction and action report output into a dedicated diagnostics module.
- Extract shared path helpers and stow action/report types while preserving the existing `rustow::stow::*` public paths.
- Simplify the binary entrypoint and split config construction into smaller helper functions.

## Validation

- `cargo fmt --check`
- `cargo clippy --locked --all-targets -- -D warnings`
- `cargo test --locked`
- `cargo build --release --locked`
- `cargo test --release --locked`
- `cargo deny check bans licenses sources`